### PR TITLE
“defaults” fallback to “{}” to avoid JSON error

### DIFF
--- a/reportstool/templates/report/new.html
+++ b/reportstool/templates/report/new.html
@@ -7,7 +7,7 @@
   <label for="id-sql">SQL:</label><textarea name="sql" id="id-sql" placeholder="SQL"></textarea>
   <label for="id-template_headers">Table Header:</label><input type="text" name="template_headers" id="id-template_headers" style="width: 100%" placeholder"Table header"/>
   <label for="id-template">Table Row Template:</label><textarea name="template" id="id-template" placeholder="Template"></textarea>
-  <label for="id-defaults">Defaults:</label><textarea name="defaults" id="id-defaults" placeholder="Default Values"></textarea>
+  <label for="id-defaults">Defaults:</label><textarea name="defaults" id="id-defaults" placeholder="Default Values">{}</textarea>
   <input type="submit" value="Add report!" />
 </form>
 

--- a/reportstool/views.py
+++ b/reportstool/views.py
@@ -82,7 +82,7 @@ def new():
         sql = request.form['sql']
         template = request.form['template']
         template_headers = request.form['template_headers']
-        defaults = request.form['defaults']
+        defaults = request.form['defaults'] or "{}"
         db = get_db()
         cur = db.cursor()
         cur.execute('INSERT INTO reports (editor, name, sql, template, template_headers, defaults) VALUES (%s, %s, %s, %s, %s, %s) RETURNING id', [current_user.id, name, sql, template, template_headers, defaults])
@@ -116,7 +116,7 @@ def report_edit(reportid):
         sql = request.form['sql']
         template = request.form['template']
         template_headers = request.form['template_headers']
-        defaults = request.form['defaults']
+        defaults = request.form['defaults'] or "{}"
         if (name != report[1] or sql != report[2] or template != report[3] or template_headers != report[4] or defaults != report[5]):
             db = get_db()
             cur = db.cursor()


### PR DESCRIPTION
Hello Ian,
I’m sending this to you just in case it is some valid Python code (that I don’t know at all) and if you feel like merging it would cause more good than bad.
Otherwise, just close it nicely.

When creating a report, I got that error :

> Query failed: No JSON object could be decoded

And it took some time of vain efforts before I searched the net and eventually found nikki’s (as usual!) solution in the chatlogs. :)

